### PR TITLE
:recycle: Add errors in JSON

### DIFF
--- a/api.go
+++ b/api.go
@@ -45,8 +45,11 @@ func generate(w http.ResponseWriter, r *http.Request) {
 
 	result, err := llm.Generate(input.ReturnType, input.Task, &callback)
 
+	w.Header()["Content-Type"] = []string{"application/json"}
+
 	if err != nil {
-		http.Error(w, "500 task failed to execute", http.StatusInternalServerError)
+		w.WriteHeader(500)
+		w.Write([]byte(result.(string)))
 		return
 	}
 

--- a/llm/openai.go
+++ b/llm/openai.go
@@ -25,14 +25,14 @@ func removeMarkdownCodeBlock(s string) string {
 func Generate(type_format any, task string, c *func(string, int, int)) (any, error) {
 	type_string, err := type_parser.TypeToString(type_format, 0)
 	if err != nil {
-		return "", err
+		return "{\"error\":\"parse_type_failed\"}", err
 	}
 
 	for i := 0; i < 5; i++ {
 		log.Printf("Trying generation %d/5\n", i+1)
 		llm, err := openai.NewChat()
 		if err != nil {
-			return "", err
+			return "{\"error\":\"llm_init_failed\"}", err
 		}
 
 		input_prompt := generateTypedPrompt(type_string, task)
@@ -41,7 +41,7 @@ func Generate(type_format any, task string, c *func(string, int, int)) (any, err
 			schema.HumanChatMessage{Text: input_prompt},
 		})
 		if err != nil {
-			return "", err
+			continue
 		}
 
 		if c != nil {
@@ -68,5 +68,5 @@ func Generate(type_format any, task string, c *func(string, int, int)) (any, err
 		return result, nil
 	}
 
-	return "", errors.New("Generation failed after 5 retries")
+	return "{\"error\":\"generation_failed\"}", errors.New("Generation failed after 5 retries")
 }


### PR DESCRIPTION
This PR adds usable JSON errors on fails from llm.Generate.

Future improvements:
 - Instead of defining the json as strings in result, we could somehow use errors message and generate a json from that.