### PR TITLE
:sparkles: Add tokenUsage in result

### DIFF
--- a/api.go
+++ b/api.go
@@ -49,7 +49,7 @@ func generate(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		w.WriteHeader(500)
-		w.Write([]byte(result.(string)))
+		w.Write([]byte(result.Result.(string)))
 		return
 	}
 


### PR DESCRIPTION
This pull request change the result of the `/generate` route to add token_usage.
The new response will look like this:
```json
{ "result": [1,2,3,4,5], "token_usage": { "input": 121, "output": 18 } }
```