### PR TITLE
:sparkles: add Dall-E 3

### DIFF
--- a/db/request_logs.go
+++ b/db/request_logs.go
@@ -37,8 +37,10 @@ func tokenToCredit(providerName string, modelName string, inputTokenCount int, o
 			return (inputTokenCount * 600) + (outputTokenCount * 1200)
 		case "text-embedding-ada-002":
 			return inputTokenCount * 1
-		case "dalle-2":
+		case "dall-e-2":
 			return 200000
+		case "dall-e-3":
+			return 800000
 		}
 	case "openrouter":
 		return codegen.OpenRouterPrices(modelName, inputTokenCount, outputTokenCount)

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pkoukk/tiktoken-go-loader v0.0.1
 	github.com/posthog/posthog-go v0.0.0-20230801140217-d607812dee69
 	github.com/rakyll/openai-go v1.0.9
-	github.com/sashabaranov/go-openai v1.14.1
+	github.com/sashabaranov/go-openai v1.17.9
 	github.com/supabase/postgrest-go v0.0.7
 	github.com/tmc/langchaingo v0.0.0-20230802030916-271e9bd7e7c5
 	gorm.io/driver/postgres v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d h1:hrujxIzL1woJ7
 github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d/go.mod h1:uugorj2VCxiV1x+LzaIdVa9b4S4qGAcH6cbhh4qVxOU=
 github.com/sashabaranov/go-openai v1.14.1 h1:jqfkdj8XHnBF84oi2aNtT8Ktp3EJ0MfuVjvcMkfI0LA=
 github.com/sashabaranov/go-openai v1.14.1/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
+github.com/sashabaranov/go-openai v1.17.9 h1:QEoBiGKWW68W79YIfXWEFZ7l5cEgZBV4/Ow3uy+5hNY=
+github.com/sashabaranov/go-openai v1.17.9/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=

--- a/image_generation/dalle.go
+++ b/image_generation/dalle.go
@@ -12,16 +12,6 @@ import (
 	openai "github.com/sashabaranov/go-openai"
 )
 
-func ModelToOpenAIFormat(model string) string {
-	switch model {
-	case "dalle-2":
-		return "dall-e-2"
-	case "dalle-3":
-		return "dall-e-3"
-	}
-	return "dall-e-2"
-}
-
 func DALLEGenerate(ctx context.Context, prompt string, model string) (io.Reader, error) {
 	var config openai.ClientConfig
 	customToken, ok := ctx.Value(utils.ContextKeyOpenAIToken).(string)

--- a/image_generation/dalle.go
+++ b/image_generation/dalle.go
@@ -29,7 +29,7 @@ func DALLEGenerate(ctx context.Context, prompt string, model string) (io.Reader,
 
 	req := openai.ImageRequest{
 		Prompt:         prompt,
-		Model:          ModelToOpenAIFormat(model),
+		Model:          model,
 		Size:           openai.CreateImageSize1024x1024,
 		ResponseFormat: openai.CreateImageResponseFormatB64JSON,
 		N:              1,

--- a/image_generation/image_generation.go
+++ b/image_generation/image_generation.go
@@ -62,10 +62,10 @@ func ImageGeneration(w http.ResponseWriter, r *http.Request, _ router.Params) {
 	}
 
 	if model == "" {
-		model = "dalle-2"
+		model = "dall-e-2"
 	}
 
-	if model != "dalle-2" && model != "dalle-3" {
+	if model != "dall-e-2" && model != "dall-e-3" {
 		utils.RespondError(w, record, "unknown_model")
 		return
 	}
@@ -74,7 +74,7 @@ func ImageGeneration(w http.ResponseWriter, r *http.Request, _ router.Params) {
 
 	db.LogRequests(
 		r.Context().Value(utils.ContextKeyEventID).(string),
-		userID, "openai", "dalle-2", 0, 0, "image", true)
+		userID, "openai", model, 0, 0, "image", true)
 
 	if err != nil {
 		utils.RespondError(w, record, "image_generation_error")

--- a/image_generation/image_generation.go
+++ b/image_generation/image_generation.go
@@ -41,7 +41,7 @@ func ImageGeneration(w http.ResponseWriter, r *http.Request, _ router.Params) {
 	userID := r.Context().Value(utils.ContextKeyUserID).(string)
 	request, _ := json.Marshal(r.URL.Query())
 	prompt := r.URL.Query().Get("p")
-	provider := r.URL.Query().Get("provider")
+	model := r.URL.Query().Get("model")
 	recordEventRequest := r.Context().Value(utils.ContextKeyRecordEventRequest).(utils.RecordRequestFunc)
 
 	var record utils.RecordFunc = func(response string, props ...utils.KeyValue) {
@@ -61,16 +61,16 @@ func ImageGeneration(w http.ResponseWriter, r *http.Request, _ router.Params) {
 		return
 	}
 
-	if provider == "" {
-		provider = "openai"
+	if model == "" {
+		model = "dalle-2"
 	}
 
-	if provider != "openai" {
-		utils.RespondError(w, record, "unknown_model_provider")
+	if model != "dalle-2" && model != "dalle-3" {
+		utils.RespondError(w, record, "unknown_model")
 		return
 	}
 
-	reader, err := DALLEGenerate(r.Context(), prompt)
+	reader, err := DALLEGenerate(r.Context(), prompt, model)
 
 	db.LogRequests(
 		r.Context().Value(utils.ContextKeyEventID).(string),


### PR DESCRIPTION
This PR adds the support for Dall-E 3.
 - added a `model` query parameter to the image generation endpoint 
 - moved the library used for image generation from `github.com/rakyll/openai-go` to `github.com/sashabaranov/go-openai`. Only whisper is still using the first one, I think we should completely move to the second one in the near future.
 - deleted the provider parameter, which was useless  since we removed MJ support
 - Renamed dalle-2 to dall-e-2 (and added dall-e-3) to respect openai naming standard. The model table needs to have theses two created and this migration will need to be executed after deployment to remove the old `dalle-2` model slug:
 ```sql
UPDATE request_logs SET model_name = 'dall-e-2' WHERE model_name = 'dalle-2';
DELETE FROM models WHERE model = 'dalle-2';`
```