### PR TITLE
:sparkles: Change cache to exact cache. Rename old cache to fuzzy cache

### DIFF
--- a/completion/cache.go
+++ b/completion/cache.go
@@ -9,7 +9,7 @@ import (
 	options "github.com/polyfire/api/llm/providers/options"
 )
 
-func CheckCache(
+func CheckFuzzyCache(
 	ctx context.Context,
 	prompt string,
 	providerName string,
@@ -26,7 +26,7 @@ func CheckCache(
 	}
 
 	if cache != nil {
-		log.Println("Cache hit")
+		log.Println("Fuzzy Cache hit")
 
 		result := make(chan options.Result)
 		go func() {
@@ -37,4 +37,28 @@ func CheckCache(
 	}
 
 	return nil, embeddings, nil
+}
+
+func CheckExactCache(
+	prompt string,
+	providerName string,
+	modelName string,
+) (chan options.Result, error) {
+	cache, err := db.GetExactCompletionCacheByHash(providerName, modelName, prompt)
+	if err != nil {
+		return nil, err
+	}
+
+	if cache != nil {
+		log.Println("Cache hit")
+
+		result := make(chan options.Result)
+		go func() {
+			defer close(result)
+			result <- options.Result{Result: cache.Result}
+		}()
+		return result, nil
+	}
+
+	return nil, nil
 }

--- a/completion/no-stream.go
+++ b/completion/no-stream.go
@@ -41,11 +41,6 @@ func Generate(w http.ResponseWriter, r *http.Request, _ router.Params) {
 	userID := r.Context().Value(utils.ContextKeyUserID).(string)
 	record := r.Context().Value(utils.ContextKeyRecordEvent).(utils.RecordFunc)
 
-	if len(r.Header["Content-Type"]) == 0 || r.Header["Content-Type"][0] != "application/json" {
-		utils.RespondError(w, record, "invalid_content_type")
-		return
-	}
-
 	var input GenerateRequestBody
 
 	err := json.NewDecoder(r.Body).Decode(&input)

--- a/db/cache.go
+++ b/db/cache.go
@@ -1,16 +1,21 @@
 package db
 
 import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
 	"strconv"
 	"strings"
 )
 
 type CompletionCache struct {
 	ID        string     `json:"id"`
+	Sha256sum string     `json:"sha256sum"`
 	Input     FloatArray `json:"input"`
 	Result    string     `json:"result"`
 	Provider  string     `json:"provider"`
 	Model     string     `json:"model"`
+	Exact     bool       `json:"exact"`
 	CreatedAt string     `json:"created_at"`
 }
 
@@ -42,7 +47,7 @@ func GetCompletionCacheByInput(provider string, model string, input []float32) (
 	var cache []CompletionCache
 	err := DB.Find(
 		&cache,
-		"provider = ? AND model = ? AND input <-> ? < 0.15 ORDER BY input <-> ? ASC",
+		"exact = false AND provider = ? AND model = ? AND input <-> ? < 0.15 ORDER BY input <-> ? ASC",
 		provider,
 		model,
 		embeddingstr,
@@ -59,16 +64,48 @@ func GetCompletionCacheByInput(provider string, model string, input []float32) (
 	return &cache[0], nil
 }
 
-func AddCompletionCache(input []float32, result string, provider string, model string) error {
+func AddCompletionCache(input []float32, prompt string, result string, provider string, model string, exact bool) error {
 	embeddingstr := ""
 	for _, v := range input {
 		embeddingstr += strconv.FormatFloat(float64(v), 'f', 6, 64) + ","
 	}
 	embeddingstr = strings.TrimRight(embeddingstr, ",") + ""
 
+	sha256sum := sha256.Sum256([]byte(prompt))
+	sha256sumHex := hex.EncodeToString(sha256sum[:])
+
 	err := DB.Exec(
-		"INSERT INTO completion_cache (result, provider, model, input) VALUES (?, ?, ?, string_to_array(?, ',')::float[])",
-		result, provider, model, embeddingstr).Error
+		"INSERT INTO completion_cache (result, provider, model, input, exact, sha256sum) VALUES (@result, @provider, @model, CASE WHEN @input = '' THEN NULL ELSE string_to_array(@input, ',')::float[] END, @exact, @sha256sum) ON CONFLICT (sha256sum) DO NOTHING;",
+		sql.Named("result", result),
+		sql.Named("provider", provider),
+		sql.Named("model", model),
+		sql.Named("input", embeddingstr),
+		sql.Named("exact", exact),
+		sql.Named("sha256sum", sha256sumHex),
+	).Error
 
 	return err
+}
+
+func GetExactCompletionCacheByHash(provider string, model string, input string) (*CompletionCache, error) {
+	sha256sum := sha256.Sum256([]byte(input))
+	sha256sumHex := hex.EncodeToString(sha256sum[:])
+
+	var cache []CompletionCache
+	err := DB.Find(
+		&cache,
+		"provider = ? AND model = ? AND sha256sum = ?",
+		provider,
+		model,
+		sha256sumHex,
+	).Error
+	if err != nil {
+		return nil, err
+	}
+
+	if len(cache) == 0 {
+		return nil, nil
+	}
+
+	return &cache[0], nil
 }

--- a/utils/error.go
+++ b/utils/error.go
@@ -101,11 +101,6 @@ var ErrorMessages = map[string]APIError{
 		Message:    "Failed to establish communication. Please try again later.",
 		StatusCode: http.StatusBadRequest,
 	},
-	"invalid_content_type": {
-		Code:       "invalid_content_type",
-		Message:    "Expected 'application/json' content type.",
-		StatusCode: http.StatusBadRequest,
-	},
 	"invalid_json": {
 		Code:       "invalid_json",
 		Message:    "Failed to decode request body. Ensure valid JSON format.",


### PR DESCRIPTION
The exact cache will now be enabled by default on temperature: 0

We do not need to document the exact cache (maybe appart from saying that there's a cache by default). The cache option can still be set to false manually but having a different result with it would be considered a bug.

I also renamed the current cache to `fuzzy_cache`. This is stays disabled by default. This can be enabled by the app developer but they must be aware that, though it might reduce their costs, it can also cause data leaks. A long prompt with a password inside would probably cause a fuzzy cache hit even without the password in it. And we cannot guarantee the LLM answer won't contain the password.
It still has its use, but the documentation should mention that this should never be enabled when sensitive or private user data are sent to the models (for example, in a private chat).