### PR TITLE
:racehorse: Support arrays of inputs in embeddings PUT

### DIFF
--- a/completion/cache.go
+++ b/completion/cache.go
@@ -17,14 +17,14 @@ func CheckFuzzyCache(
 	modelName string,
 ) (chan options.Result, []float32, error) {
 	db := ctx.Value(utils.ContextKeyDB).(database.Database)
-	embeddings, err := llm.Embed(ctx, prompt, nil)
+	embeddings, err := llm.Embed(ctx, []string{prompt}, nil)
 	if err != nil {
-		return nil, embeddings, err
+		return nil, embeddings[0], err
 	}
 
-	cache, err := db.GetCompletionCacheByInput(providerName, modelName, embeddings)
+	cache, err := db.GetCompletionCacheByInput(providerName, modelName, embeddings[0])
 	if err != nil {
-		return nil, embeddings, err
+		return nil, embeddings[0], err
 	}
 
 	if cache != nil {
@@ -34,10 +34,10 @@ func CheckFuzzyCache(
 			defer close(result)
 			result <- options.Result{Result: cache.Result}
 		}()
-		return result, embeddings, nil
+		return result, embeddings[0], nil
 	}
 
-	return nil, embeddings, nil
+	return nil, embeddings[0], nil
 }
 
 func CheckExactCache(

--- a/completion/context.go
+++ b/completion/context.go
@@ -5,26 +5,9 @@ import (
 	"sync"
 
 	completionContext "github.com/polyfire/api/completion/context"
-	options "github.com/polyfire/api/llm/providers/options"
+	"github.com/polyfire/api/llm/providers/options"
+	"github.com/polyfire/api/utils"
 )
-
-func parseMemoryIDArray(memoryID interface{}) []string {
-	var memoryIDArray []string
-
-	var str string
-	var ok bool
-	var array []interface{}
-	if str, ok = memoryID.(string); ok {
-		memoryIDArray = append(memoryIDArray, str)
-	} else if array, ok = memoryID.([]interface{}); ok {
-		for _, item := range array {
-			if str, ok = item.(string); ok {
-				memoryIDArray = append(memoryIDArray, str)
-			}
-		}
-	}
-	return memoryIDArray
-}
 
 func launchContextFillingGoRouting(
 	wg *sync.WaitGroup,
@@ -57,7 +40,7 @@ func GetContextString(
 	contextElements := make([]completionContext.ContentElement, 0)
 
 	launchContextFillingGoRouting(&wg, &contextElements, func() (completionContext.ContentElement, error) {
-		return completionContext.GetMemory(ctx, userID, parseMemoryIDArray(input.MemoryID), input.Task)
+		return completionContext.GetMemory(ctx, userID, utils.StringOptionalArray(input.MemoryID), input.Task)
 	})
 
 	var warnings []string

--- a/db/db.go
+++ b/db/db.go
@@ -71,6 +71,7 @@ type Database interface {
 	CreateMemory(memoryID string, userID string, public bool) error
 	GetMemory(memoryID string) (*Memory, error)
 	AddMemory(userID string, memoryID string, content string, embedding []float32) error
+	AddMemories(memoryID string, embeddings []Embedding) error
 	GetExistingEmbeddingFromContent(content string) (*[]float32, error)
 	GetMemoryIDs(userID string) ([]MemoryRecord, error)
 	MatchEmbeddings(memoryIDs []string, userID string, embedding []float32) ([]MatchResult, error)

--- a/db/mock_db.go
+++ b/db/mock_db.go
@@ -34,6 +34,7 @@ type MockDatabase struct {
 	MockCreateMemory                    func(memoryID string, userID string, public bool) error
 	MockGetMemory                       func(memoryID string) (*Memory, error)
 	MockAddMemory                       func(userID string, memoryID string, content string, embedding []float32) error
+	MockAddMemories                     func(memoryID string, embeddings []Embedding) error
 	MockGetExistingEmbeddingFromContent func(content string) (*[]float32, error)
 	MockGetMemoryIDs                    func(userID string) ([]MemoryRecord, error)
 	MockMatchEmbeddings                 func(memoryIDs []string, userID string, embedding []float32) ([]MatchResult, error)
@@ -79,6 +80,10 @@ func (mdb MockDatabase) GetExistingEmbeddingFromContent(content string) (*[]floa
 
 func (mdb MockDatabase) AddMemory(_ string, _ string, _ string, _ []float32) error {
 	panic("Mock AddMemory Unimplemented")
+}
+
+func (mdb MockDatabase) AddMemories(_ string, _ []Embedding) error {
+	panic("Mock AddMemories Unimplemented")
 }
 
 func (mdb MockDatabase) GetMemory(_ string) (*Memory, error) {

--- a/llm/embeddings.go
+++ b/llm/embeddings.go
@@ -8,28 +8,17 @@ import (
 	llmTokens "github.com/polyfire/api/tokens"
 	goOpenai "github.com/sashabaranov/go-openai"
 
-	database "github.com/polyfire/api/db"
 	"github.com/polyfire/api/utils"
 )
 
-func Embed(ctx context.Context, content string, c *func(string, int)) ([]float32, error) {
-	db := ctx.Value(utils.ContextKeyDB).(database.Database)
-	alreadyExistingEmbedding, err := db.GetExistingEmbeddingFromContent(content)
-	if err != nil {
-		return nil, err
-	}
-
-	if alreadyExistingEmbedding != nil {
-		return *alreadyExistingEmbedding, nil
-	}
-
+func Embed(ctx context.Context, contents []string, c *func(string, int)) ([][]float32, error) {
 	userID := ctx.Value(utils.ContextKeyUserID).(string)
 
 	client := providers.NewOpenAIStreamProvider(ctx, fmt.Sprint(goOpenai.AdaEmbeddingV2)).Client
 
 	embeddingCtx := context.Background()
 	res, err := client.CreateEmbeddings(embeddingCtx, goOpenai.EmbeddingRequestStrings{
-		Input: []string{content},
+		Input: contents,
 		Model: goOpenai.AdaEmbeddingV2,
 		User:  userID,
 	})
@@ -37,11 +26,18 @@ func Embed(ctx context.Context, content string, c *func(string, int)) ([]float32
 		return nil, err
 	}
 
-	embeddings := res.Data[0].Embedding
+	var embeddings [][]float32
+
+	for _, embed := range res.Data {
+		embeddings = append(embeddings, embed.Embedding)
+	}
 
 	model := "text-embedding-ada-002"
 
-	tokenUsage := llmTokens.CountTokens(content)
+	tokenUsage := 0
+	for _, content := range contents {
+		tokenUsage += llmTokens.CountTokens(content)
+	}
 
 	if c != nil {
 		(*c)(model, tokenUsage)

--- a/tokens/tokens.go
+++ b/tokens/tokens.go
@@ -1,6 +1,8 @@
 package tokens
 
 import (
+	"errors"
+
 	tiktoken "github.com/pkoukk/tiktoken-go"
 	tiktoken_loader "github.com/pkoukk/tiktoken-go-loader"
 )
@@ -22,4 +24,51 @@ func CountTokens(text string) int {
 	token := tke.Encode(text, nil, nil)
 
 	return len(token)
+}
+
+func SplitText(text string, chunkSize int) []string {
+	splits := make([]string, 0)
+	inputIds := tke.Encode(text, nil, nil)
+
+	startIdx := 0
+	curIdx := len(inputIds)
+	if startIdx+chunkSize < curIdx {
+		curIdx = startIdx + chunkSize
+	}
+	for startIdx < len(inputIds) {
+		chunkIds := inputIds[startIdx:curIdx]
+		splits = append(splits, tke.Decode(chunkIds))
+		startIdx += chunkSize
+		curIdx = startIdx + chunkSize
+		if curIdx > len(inputIds) {
+			curIdx = len(inputIds)
+		}
+	}
+	return splits
+}
+
+func BatchText(input []string, maxBatchTokenSize int) ([][]string, error) {
+	res := make([][]string, 0)
+	currentBatch := make([]string, 0)
+	currentBatchToken := 0
+
+	for _, curr := range input {
+		currTokens := CountTokens(curr)
+
+		if currTokens > maxBatchTokenSize {
+			return nil, errors.New("BatchText: One of the input is bigger than maxBatchTokenSize")
+		}
+
+		if currentBatchToken+currTokens > maxBatchTokenSize {
+			res = append(res, currentBatch)
+			currentBatchToken = 0
+			currentBatch = make([]string, 0)
+		}
+
+		currentBatch = append(currentBatch, curr)
+		currentBatchToken += currTokens
+	}
+
+	res = append(res, currentBatch)
+	return res, nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -94,3 +94,24 @@ func SetLogLevel(lvl string) {
 	}
 	log.SetOutput(filter)
 }
+
+func StringOptionalArray(elem interface{}) []string {
+	var elemArray []string
+
+	var str string
+	var ok bool
+	var array []interface{}
+	if str, ok = elem.(string); ok {
+		elemArray = append(elemArray, str)
+	} else if array, ok = elem.([]interface{}); ok {
+		for _, item := range array {
+			if str, ok = item.(string); ok {
+				if len(str) == 0 {
+					continue
+				}
+				elemArray = append(elemArray, str)
+			}
+		}
+	}
+	return elemArray
+}


### PR DESCRIPTION
This PR adds the support for input arrays when adding an embedding to a memory.
This uses:
- a new query `AddMemories` instead of the old `AddMemory` which allows to insert all the new embeddings in a single db query
- a batching system to minimize the number of LLM calls. Note that this cannot be done in a single query since OpenAI compatible API expects the total of inputs of one query to be under a max token amount (~2048 for openai)