### PR TITLE
:zap: stt: Remove silences directly in the API and take it into account for words/dialogues timestamps

### DIFF
--- a/stt/providers/deepgram.go
+++ b/stt/providers/deepgram.go
@@ -49,6 +49,8 @@ func (DeepgramProvider) Transcribe(
 	dialogueElem := DialogueElement{
 		Speaker: 0,
 		Text:    "",
+		Start:   0,
+		End:     0,
 	}
 
 	if len(res.Results.Channels) > 0 {
@@ -57,6 +59,9 @@ func (DeepgramProvider) Transcribe(
 			lastSpeaker := 0
 			lastPunctatedWord := " "
 			for _, word := range res.Results.Channels[0].Alternatives[0].Words {
+				if dialogueElem.Start == 0 {
+					dialogueElem.Start = word.Start
+				}
 				if (word.Speaker != nil || *(word.Speaker) != lastSpeaker) &&
 					(word.SpeakerConfidence < 0.7) && rune(lastPunctatedWord[len(lastPunctatedWord)-1]) != '.' {
 					speaker := lastSpeaker
@@ -70,10 +75,12 @@ func (DeepgramProvider) Transcribe(
 					dialogueElem = DialogueElement{
 						Speaker: *(word.Speaker),
 						Text:    "",
+						Start:   word.Start,
 					}
 				}
 
 				dialogueElem.Text += " " + word.Punctuated_Word
+				dialogueElem.End = word.End
 
 				words = append(words, Word{
 					Word:              word.Word,

--- a/stt/providers/options.go
+++ b/stt/providers/options.go
@@ -23,8 +23,10 @@ type TranscriptionInputOptions struct {
 }
 
 type DialogueElement struct {
-	Speaker int    `json:"speaker"`
-	Text    string `json:"text"`
+	Speaker int     `json:"speaker"`
+	Text    string  `json:"text"`
+	Start   float64 `json:"start"`
+	End     float64 `json:"end"`
 }
 
 type TranscriptionResult struct {

--- a/stt/silence.go
+++ b/stt/silence.go
@@ -131,7 +131,7 @@ func RemoveSilence(file io.Reader) ([]Silence, io.Reader, func(), error) {
 		afOpts = append(afOpts, fmt.Sprintf("aselect='not(between(t\\,%f\\,%f))'", start, end))
 	}
 
-	b, err = exec.Command("bash", "-c", "ffmpeg -i \"/tmp/"+id+"/audio-file\" -vf "+strings.Join(vfOpts, ",")+" -af "+strings.Join(afOpts, ",")+" /tmp/"+id+"/audio-file-no-silence.mp3").
+	_, err = exec.Command("bash", "-c", "ffmpeg -i \"/tmp/"+id+"/audio-file\" -vf "+strings.Join(vfOpts, ",")+" -af "+strings.Join(afOpts, ",")+" /tmp/"+id+"/audio-file-no-silence.mp3").
 		CombinedOutput()
 	if err != nil {
 		return nil, nil, closeFunc, err

--- a/stt/silence.go
+++ b/stt/silence.go
@@ -1,0 +1,146 @@
+package stt
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	providers "github.com/polyfire/api/stt/providers"
+)
+
+type Silence struct {
+	Start    float64
+	End      float64
+	Duration float64
+}
+
+/*	WARNING: This function requires silences to be sorted by ascending start
+ *  timestamp. As of 2024-02-07 the RemoveSilence function should already return
+ *  sorted silences. If it changes at any point in the future we would need to
+ *  sort it manually or timestamps could be wrong. */
+func AddSilenceToTimestamp(silences []Silence, timestamp float64) float64 {
+	res := timestamp
+	for _, s := range silences {
+		if s.Start <= res {
+			res += s.Duration
+		}
+	}
+
+	return res
+}
+
+func AddSilenceToWordTimestamps(silences []Silence, words []providers.Word) []providers.Word {
+	res := make([]providers.Word, 0)
+	for _, w := range words {
+		res = append(res, providers.Word{
+			Word:              w.Word,
+			PunctuatedWord:    w.PunctuatedWord,
+			Start:             AddSilenceToTimestamp(silences, w.Start),
+			End:               AddSilenceToTimestamp(silences, w.End),
+			Confidence:        w.Confidence,
+			Speaker:           w.Speaker,
+			SpeakerConfidence: w.SpeakerConfidence,
+		})
+	}
+
+	return res
+}
+
+func AddSilenceToDialogueTimestamps(silences []Silence, words []providers.DialogueElement) []providers.DialogueElement {
+	res := make([]providers.DialogueElement, 0)
+	for _, w := range words {
+		res = append(res, providers.DialogueElement{
+			Speaker: w.Speaker,
+			Text:    w.Text,
+			Start:   AddSilenceToTimestamp(silences, w.Start),
+			End:     AddSilenceToTimestamp(silences, w.End),
+		})
+	}
+
+	return res
+}
+
+func RemoveSilence(file io.Reader) ([]Silence, io.Reader, func(), error) {
+	id := "split_transcribe-" + uuid.New().String()
+	_ = os.Mkdir("/tmp/"+id, 0700)
+	closeFunc := func() {
+		os.RemoveAll("/tmp/" + id)
+	}
+
+	f, err := os.Create("/tmp/" + id + "/audio-file")
+	if err != nil {
+		return nil, nil, closeFunc, err
+	}
+
+	_, err = io.Copy(f, file)
+	if err != nil {
+		return nil, nil, closeFunc, err
+	}
+
+	b, err := exec.Command("bash", "-c", "ffmpeg -i \"/tmp/"+id+"/audio-file\" -af \"silencedetect=d=1\" -f null - |& tr '\\r' '\\n' | grep silence_end").
+		CombinedOutput()
+	if err != nil {
+		return nil, nil, closeFunc, err
+	}
+
+	res := strings.Split(strings.ReplaceAll(string(b), "\r", "\n"), "\n")
+
+	silences := make([]Silence, 0)
+	vfOpts := make([]string, 0)
+	afOpts := make([]string, 0)
+	for _, s := range res {
+		r, err := regexp.Compile(
+			`^\[silencedetect.*\] silence_end: (?P<silenceend>[0-9.]+) \| silence_duration: (?P<silenceduration>[0-9.]+)$`,
+		)
+		if err != nil {
+			return nil, nil, closeFunc, err
+		}
+		m := r.FindStringSubmatch(s)
+		if len(m) < 2 {
+			continue
+		}
+
+		result := make(map[string]string)
+		for i, name := range r.SubexpNames() {
+			if i != 0 && name != "" {
+				result[name] = m[i]
+			}
+		}
+
+		end, err := strconv.ParseFloat(result["silenceend"], 64)
+		if err != nil {
+			return nil, nil, closeFunc, err
+		}
+		duration, err := strconv.ParseFloat(result["silenceduration"], 64)
+		if err != nil {
+			return nil, nil, closeFunc, err
+		}
+		start := end - duration
+		silences = append(silences, Silence{
+			Start:    start,
+			Duration: duration,
+			End:      end,
+		})
+
+		vfOpts = append(vfOpts, fmt.Sprintf("select='not(between(t\\,%f\\,%f))'", start, end))
+		afOpts = append(afOpts, fmt.Sprintf("aselect='not(between(t\\,%f\\,%f))'", start, end))
+	}
+
+	b, err = exec.Command("bash", "-c", "ffmpeg -i \"/tmp/"+id+"/audio-file\" -vf "+strings.Join(vfOpts, ",")+" -af "+strings.Join(afOpts, ",")+" /tmp/"+id+"/audio-file-no-silence.mp3").
+		CombinedOutput()
+	if err != nil {
+		return nil, nil, closeFunc, err
+	}
+
+	noSilenceReader, err := os.Open("/tmp/" + id + "/audio-file-no-silence.mp3")
+	if err != nil {
+		return nil, nil, closeFunc, err
+	}
+
+	return silences, noSilenceReader, closeFunc, nil
+}

--- a/stt/split.go
+++ b/stt/split.go
@@ -1,0 +1,87 @@
+package stt
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+func SplitFile(file io.Reader) ([]io.Reader, int, func(), error) {
+	id := "split_transcribe-" + uuid.New().String()
+	_ = os.Mkdir("/tmp/"+id, 0700)
+	closeFunc := func() {
+		os.RemoveAll("/tmp/" + id)
+	}
+	fmt.Println(id)
+
+	f, err := os.Create("/tmp/" + id + "/audio-file")
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
+	_, err = io.Copy(f, file)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
+	err = exec.Command("ffmpeg", "-i", "/tmp/"+id+"/audio-file", "/tmp/"+id+"/audio-file.ts", "-ar", "44100").Run()
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
+	ffprobeResult, err := exec.Command("ffprobe", "-i", "/tmp/"+id+"/audio-file.ts", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", "-v", "quiet", "-of", "csv=p=0").
+		Output()
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
+	durationFfprobe := strings.Split(strings.Trim(string(ffprobeResult), " \t\n"), ".")
+
+	durationSeconds, err := strconv.Atoi(durationFfprobe[0])
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
+	durationSeconds = durationSeconds + 1
+	os.Remove("/tmp/" + id + "/audio-file")
+
+	splitCmd := exec.Command("split", "-b", "20971400", "/tmp/"+id+"/audio-file.ts")
+	splitCmd.Dir = "/tmp/" + id
+	err = splitCmd.Run()
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
+	os.Remove("/tmp/" + id + "/audio-file.ts")
+	files, err := os.ReadDir("/tmp/" + id)
+	if err != nil {
+		fmt.Println("readdir")
+		return nil, 0, nil, err
+	}
+
+	res := make([]io.Reader, 0)
+	for _, file := range files {
+		if file.Name() != "audio-file" && file.Name() != "audio-file.mpeg" {
+			err := exec.Command("ffmpeg", "-i", "/tmp/"+id+"/"+file.Name(), "/tmp/"+id+"/"+file.Name()+".mp3").Run()
+			if err != nil {
+				return nil, 0, nil, err
+			}
+
+			os.Remove("/tmp/" + id + "/" + file.Name())
+			audioPartR, err := os.Open("/tmp/" + id + "/" + file.Name() + ".mp3")
+			if err != nil {
+				fmt.Println("open part")
+				return nil, 0, nil, err
+			}
+			res = append(res, audioPartR)
+			fmt.Println("adding:", file.Name())
+		}
+	}
+
+	return res, durationSeconds, closeFunc, nil
+}

--- a/stt/transcribe.go
+++ b/stt/transcribe.go
@@ -10,12 +10,9 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
-	"os/exec"
-	"strconv"
 	"strings"
 	"sync"
 
-	"github.com/google/uuid"
 	router "github.com/julienschmidt/httprouter"
 	supa "github.com/nedpals/supabase-go"
 
@@ -23,81 +20,6 @@ import (
 	providers "github.com/polyfire/api/stt/providers"
 	"github.com/polyfire/api/utils"
 )
-
-func SplitFile(file io.Reader) ([]io.Reader, int, func(), error) {
-	id := "split_transcribe-" + uuid.New().String()
-	_ = os.Mkdir("/tmp/"+id, 0700)
-	closeFunc := func() {
-		os.RemoveAll("/tmp/" + id)
-	}
-	fmt.Println(id)
-
-	f, err := os.Create("/tmp/" + id + "/audio-file")
-	if err != nil {
-		return nil, 0, nil, err
-	}
-
-	_, err = io.Copy(f, file)
-	if err != nil {
-		return nil, 0, nil, err
-	}
-
-	err = exec.Command("ffmpeg", "-i", "/tmp/"+id+"/audio-file", "/tmp/"+id+"/audio-file.ts", "-ar", "44100").Run()
-	if err != nil {
-		return nil, 0, nil, err
-	}
-
-	ffprobeResult, err := exec.Command("ffprobe", "-i", "/tmp/"+id+"/audio-file.ts", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", "-v", "quiet", "-of", "csv=p=0").
-		Output()
-	if err != nil {
-		return nil, 0, nil, err
-	}
-
-	durationFfprobe := strings.Split(strings.Trim(string(ffprobeResult), " \t\n"), ".")
-
-	durationSeconds, err := strconv.Atoi(durationFfprobe[0])
-	if err != nil {
-		return nil, 0, nil, err
-	}
-
-	durationSeconds = durationSeconds + 1
-	os.Remove("/tmp/" + id + "/audio-file")
-
-	splitCmd := exec.Command("split", "-b", "20971400", "/tmp/"+id+"/audio-file.ts")
-	splitCmd.Dir = "/tmp/" + id
-	err = splitCmd.Run()
-	if err != nil {
-		return nil, 0, nil, err
-	}
-
-	os.Remove("/tmp/" + id + "/audio-file.ts")
-	files, err := os.ReadDir("/tmp/" + id)
-	if err != nil {
-		fmt.Println("readdir")
-		return nil, 0, nil, err
-	}
-
-	res := make([]io.Reader, 0)
-	for _, file := range files {
-		if file.Name() != "audio-file" && file.Name() != "audio-file.mpeg" {
-			err := exec.Command("ffmpeg", "-i", "/tmp/"+id+"/"+file.Name(), "/tmp/"+id+"/"+file.Name()+".mp3").Run()
-			if err != nil {
-				return nil, 0, nil, err
-			}
-
-			os.Remove("/tmp/" + id + "/" + file.Name())
-			audioPartR, err := os.Open("/tmp/" + id + "/" + file.Name() + ".mp3")
-			if err != nil {
-				fmt.Println("open part")
-				return nil, 0, nil, err
-			}
-			res = append(res, audioPartR)
-			fmt.Println("adding:", file.Name())
-		}
-	}
-
-	return res, durationSeconds, closeFunc, nil
-}
 
 func DownloadFromBucket(bucket string, path string) ([]byte, error) {
 	supabaseURL := os.Getenv("SUPABASE_URL")
@@ -213,7 +135,9 @@ func Transcribe(w http.ResponseWriter, r *http.Request, _ router.Params) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			resTmp, err := provider.Transcribe(ctx, fileReader, providers.TranscriptionInputOptions{
+			silences, noSilenceFileReader, closeFunc, err := RemoveSilence(fileReader)
+			defer closeFunc()
+			resTmp, err := provider.Transcribe(ctx, noSilenceFileReader, providers.TranscriptionInputOptions{
 				Format:   "mpeg",
 				Language: input.Language,
 			})
@@ -223,8 +147,14 @@ func Transcribe(w http.ResponseWriter, r *http.Request, _ router.Params) {
 				return
 			}
 			texts[chunkNb] = resTmp.Text
-			wordLists[chunkNb] = resTmp.Words
-			dialogues[chunkNb] = resTmp.Dialogue
+			/* WARNING: The timestamp will be wrong if the file has been chunked because
+			 * based on the chunked time and not the full time. For now I choose to ignore
+			 * it since the chunking is only used with whisper and the timestamp per words
+			 * is only available on deepgram. If it causes a problem at some point it might
+			 * be a good idea to move the chunking to the whisper provider function and add
+			 * an equivalent timestamp translation step */
+			wordLists[chunkNb] = AddSilenceToWordTimestamps(silences, resTmp.Words)
+			dialogues[chunkNb] = AddSilenceToDialogueTimestamps(silences, resTmp.Dialogue)
 			fmt.Printf("Transcription %v/%v\n", chunkNb+1, len(files))
 		}()
 	}

--- a/stt/transcribe.go
+++ b/stt/transcribe.go
@@ -137,6 +137,11 @@ func Transcribe(w http.ResponseWriter, r *http.Request, _ router.Params) {
 			defer wg.Done()
 			silences, noSilenceFileReader, closeFunc, err := RemoveSilence(fileReader)
 			defer closeFunc()
+			if err != nil {
+				fmt.Printf("%v\n", err)
+				utils.RespondError(w, record, "transcription_error")
+				return
+			}
 			resTmp, err := provider.Transcribe(ctx, noSilenceFileReader, providers.TranscriptionInputOptions{
 				Format:   "mpeg",
 				Language: input.Language,


### PR DESCRIPTION
This PR add the silence removing part directly in the API.

I argued against this in the past so here's my new reasoning:
 - We often need to remove the silence to avoid the models from  the STT models from hallucinating "demon speak"
 - The removed silence must be taken into account in the words/dialogues timestamp.
 - While removing silence with ffmpeg on the client side is pretty straightforward, removing them while listing them to convert the timestamp is actually more difficult (since the ffmpeg silenceremove filter doesn't list the removed part).