### PR TITLE
:zap: Return 400 on empty embedding instead of 500

### DIFF
--- a/llm/providers/openai.go
+++ b/llm/providers/openai.go
@@ -118,6 +118,11 @@ func (m OpenAIStreamProvider) Generate(
 			if errors.Is(err, io.EOF) || err != nil {
 				break
 			}
+
+			if len(completion.Choices) == 0 {
+				continue
+			}
+
 			tokenUsage.Output = tokens.CountTokens(completion.Choices[0].Delta.Content)
 
 			totalOutput += tokenUsage.Output

--- a/memory/memory.go
+++ b/memory/memory.go
@@ -86,7 +86,14 @@ func Add(w http.ResponseWriter, r *http.Request, _ router.Params) {
 
 	chunks := make([]string, 0)
 
-	for _, input := range utils.StringOptionalArray(requestBody.Input) {
+	inputs := utils.StringOptionalArray(requestBody.Input)
+
+	if len(inputs) == 0 || (len(inputs) == 1 && len(inputs[0]) == 0) {
+		utils.RespondError(w, record, "empty_input")
+		return
+	}
+
+	for _, input := range inputs {
 		chunk := tokens.SplitText(input, chunkSize)
 
 		chunks = append(chunks, chunk[:]...)

--- a/utils/error.go
+++ b/utils/error.go
@@ -126,6 +126,11 @@ var ErrorMessages = map[string]APIError{
 		Message:    "Failed to decode the incoming request. Please verify the request format.",
 		StatusCode: http.StatusBadRequest,
 	},
+	"empty_input": {
+		Code:       "empty_input",
+		Message:    "The embedding input is empty, please provide at least one string to embed.",
+		StatusCode: http.StatusBadRequest,
+	},
 	"generation_error": {
 		Code:       "generation_error",
 		Message:    "An error occurred while starting the generation. Please try again.",


### PR DESCRIPTION
This PR adds a specific 400 Bad request error "empty_input" when an empty embedding request is sent instead of the previous 500 Internal server error "embedding_error"