### PR TITLE
:sparkles: Add support for gpt-4o and gpt-4-turbo

### DIFF
--- a/db/request_logs.go
+++ b/db/request_logs.go
@@ -33,13 +33,17 @@ func tokenToCredit(
 	case "openai":
 		switch modelName {
 		case "gpt-3.5-turbo":
-			return (inputTokenCount * 15) + (outputTokenCount * 20)
+			return (inputTokenCount * 5) + (outputTokenCount * 15)
 		case "gpt-3.5-turbo-16k":
-			return (inputTokenCount * 30) + (outputTokenCount * 40)
+			return (inputTokenCount * 5) + (outputTokenCount * 15)
 		case "gpt-4":
 			return (inputTokenCount * 300) + (outputTokenCount * 600)
 		case "gpt-4-32k":
 			return (inputTokenCount * 600) + (outputTokenCount * 1200)
+		case "gpt-4o":
+			return (inputTokenCount * 50) + (outputTokenCount * 150)
+		case "gpt-4-turbo":
+			return (inputTokenCount * 100) + (outputTokenCount * 300)
 		case "text-embedding-ada-002":
 			return inputTokenCount * 1
 		case "dall-e-2":

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -18,7 +18,11 @@ var ErrUnknownModel = errors.New("Unknown model")
 type Provider interface {
 	Name() string
 	ProviderModel() (string, string)
-	Generate(prompt string, c options.ProviderCallback, opts *options.ProviderOptions) chan options.Result
+	Generate(
+		prompt string,
+		c options.ProviderCallback,
+		opts *options.ProviderOptions,
+	) chan options.Result
 	DoesFollowRateLimit() bool
 }
 
@@ -35,11 +39,15 @@ func getAvailableModels(model string) (string, string) {
 	case "gpt-3.5-turbo":
 		return "openai", "gpt-3.5-turbo"
 	case "gpt-3.5-turbo-16k":
-		return "openai", "gpt-3.5-turbo-16k"
+		return "openai", "gpt-3.5-turbo"
 	case "gpt-4":
 		return "openai", "gpt-4"
 	case "gpt-4-32k":
 		return "openai", "gpt-4-32k"
+	case "gpt-4o":
+		return "openai", "gpt-4o"
+	case "gpt-4-turbo":
+		return "openai", "gpt-4-turbo"
 	case "cohere":
 		return "cohere", "cohere_command"
 	case "llama-2-70b-chat":
@@ -59,7 +67,11 @@ func getAvailableModels(model string) (string, string) {
 	return "", ""
 }
 
-func getModelWithAliases(ctx context.Context, modelAlias string, projectID string) (string, string) {
+func getModelWithAliases(
+	ctx context.Context,
+	modelAlias string,
+	projectID string,
+) (string, string) {
 	db := ctx.Value(utils.ContextKeyDB).(database.Database)
 	provider, model := getAvailableModels(modelAlias)
 


### PR DESCRIPTION
This PR:
 - adds the support for gpt-4o and gpt-4-turbo directly with openai (not using openrouter).
 - adjust the gpt-3.5-turbo prices that have changed since the code was first written
 -  redirects the gpt-3.5-turbo-16k model to gpt-3.5-turbo (which now already supports 16k by default), since the gpt-3.5-turbo-16k is expected to be deprecated on 2024-06-13